### PR TITLE
filesystem hook, quality of life improvements, game path fixes

### DIFF
--- a/src/logfile.cpp
+++ b/src/logfile.cpp
@@ -16,7 +16,7 @@ namespace LogFile {
         }
 
         FILE* logFile = nullptr;
-        _wfopen_s(&logFile, makeToolPath(L"\\d3hook.log").c_str(), bCreateLog ? L"w" : L"a+");
+        _wfopen_s(&logFile, makeToolPath(L"logs\\d3hook.log").c_str(), bCreateLog ? L"w" : L"a+");
 
         if (logFile == nullptr)
         {

--- a/src/logfile.cpp
+++ b/src/logfile.cpp
@@ -1,4 +1,5 @@
 #include "logfile.h"
+#include "util.h"
 
 namespace LogFile {
     bool bCreateLog = true;
@@ -14,9 +15,10 @@ namespace LogFile {
             OutputDebugStringA(str);
         }
 
-        FILE *logFile = fopen("d3hook.log", ((bCreateLog) ? "w" : "a+"));
+        FILE* logFile = nullptr;
+        _wfopen_s(&logFile, makeToolPath(L"\\d3hook.log").c_str(), bCreateLog ? L"w" : L"a+");
 
-        if (logFile == NULL)
+        if (logFile == nullptr)
         {
             debug("Failed to open the log file!");
             return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -120,9 +120,23 @@ static void invokeEntry(void(*ep)())
 	}
 }
 
+static void buildDirectoryStructure()
+{
+	auto create_if = [](const wchar_t* rDir)
+	{
+		auto total = makeToolPath(rDir);
+		if (GetFileAttributesW(total.c_str()) == INVALID_FILE_ATTRIBUTES)
+			CreateDirectoryW(total.c_str(), nullptr);
+	};
+
+	create_if(L"logs");
+	create_if(L"mods");
+}
+
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
 {
 	LogFile::WriteLine("Initializing D3Hook...");
+	buildDirectoryStructure();
 
 	auto gamePath = makeGamePath(L"");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <clocale>
 
 #include "minldr.h"
+#include "util.h"
 
 void Initialize(RSDSEntry& gameInfo);
 
@@ -55,127 +56,19 @@ void WINAPI GetStartupInfoA_Stub(LPSTARTUPINFOA lpStartupInfo)
 	}
 }
 
-std::wstring make_abs_path(const std::wstring& rel_to)
-{
-	static wchar_t executable_path[MAX_PATH] = { '\0' };
-
-	if (executable_path[0] == '\0') {
-		wchar_t buf[MAX_PATH];
-		GetModuleFileNameW((HMODULE)nullptr, buf, MAX_PATH);
-		_wsplitpath(buf, &executable_path[0], &executable_path[_MAX_DRIVE - 1], nullptr, nullptr);
-	}
-
-	wchar_t buf[MAX_PATH];
-	lstrcpyW(buf, executable_path);
-	lstrcatW(buf, rel_to.c_str());
-
-	wchar_t final_buf[MAX_PATH] = { '\0' };
-	PathCanonicalizeW(final_buf, buf);
-
-	return final_buf;
-}
-
-static std::wstring g_gameRoot;
-
-//TODO: make this not shit?
-// workaround for "bug" at + 005A6937
+// as the game fetches its own path via command line,
+// we supply a fake command line (see +0x005A6937)
 const char* WINAPI GetCommandLineA_Fake()
 {
-	static std::string poop;
+	static std::string fakeCmdl;
 
-	if (poop.empty()) {
+	if (fakeCmdl.empty()) {
 		using convert_type = std::codecvt_utf8<wchar_t>;
 		std::wstring_convert<convert_type, wchar_t> converter;
-		poop = converter.to_bytes(g_gameRoot) + "\\notfake.exe";
+		fakeCmdl = converter.to_bytes(makeGamePath(L"notfake.exe"));
 	}
 
-	return poop.c_str();
-}
-
-std::wstring GetGamePath()
-{
-	HKEY hKey;
-	DWORD dwType = REG_SZ, size = MAX_PATH;
-	wchar_t inst_dir[MAX_PATH] = { 0 };
-
-	if (RegOpenKeyExW(HKEY_CURRENT_USER, L"SOFTWARE\\Fireboyd78\\d3hook", NULL, KEY_READ, &hKey) == ERROR_SUCCESS)
-	{
-		RegQueryValueExW(
-			hKey, L"gameBin", nullptr, &dwType, reinterpret_cast<LPBYTE>(inst_dir), &size);
-		RegCloseKey(hKey);
-	}
-	else
-	{
-		OPENFILENAMEW file;
-		ZeroMemory(&file, sizeof(file));
-
-		wchar_t path[MAX_PATH] = { 0 };
-		file.lStructSize = sizeof(file);
-		file.nMaxFile = MAX_PATH;
-		file.lpstrFilter = L"Executables\0*.exe\0";
-		file.lpstrDefExt = L"EXE";
-		file.lpstrTitle = L"Please select your Driver executable (Driv3r.exe)";
-		file.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_ENABLESIZING | OFN_EXPLORER;
-
-		file.lpstrFile = path;
-		file.lpstrInitialDir = path;
-
-		auto hr = GetOpenFileNameW(&file);
-		if (!hr)
-		{
-			MessageBoxW(nullptr, L"Failed to retrieve gamepath and game-executable. Cannot launch D3Hook!", L"D3Hook", MB_OK);
-			TerminateProcess(GetCurrentProcess(), 0);
-		}
-
-		std::wstring str = path;
-		std::replace(str.begin(), str.end(), '\\', '/');
-
-		str = str.substr(0, str.find_last_of(L"/") + 1);
-
-		//read the file's headers to verify its x86
-		bool isCorrectMachineType = false;
-		const HANDLE h_mapping = INVALID_HANDLE_VALUE;
-		const HANDLE h_file = CreateFileW(path, GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING,
-			FILE_ATTRIBUTE_READONLY, nullptr);
-		if (h_file != INVALID_HANDLE_VALUE)
-		{
-			const HANDLE h_mapping = CreateFileMapping(h_file, nullptr, PAGE_READONLY | SEC_IMAGE, 0, 0, nullptr);
-			if (h_mapping != INVALID_HANDLE_VALUE)
-			{
-				const LPVOID addr_header = MapViewOfFile(h_mapping, FILE_MAP_READ, 0, 0, 0);
-				if (addr_header != nullptr)
-				{
-					const PIMAGE_NT_HEADERS pe_hdr = ImageNtHeader(addr_header);
-					if (pe_hdr != nullptr)
-					{
-						isCorrectMachineType = (pe_hdr->FileHeader.Machine == IMAGE_FILE_MACHINE_I386);
-					}
-				}
-			}
-		}
-
-		if (h_file != INVALID_HANDLE_VALUE)
-			CloseHandle(h_file);
-
-		if (h_mapping != INVALID_HANDLE_VALUE)
-			CloseHandle(h_mapping);
-
-		if (!isCorrectMachineType)
-		{
-			MessageBoxA(nullptr, "The selected executable is a non x86 bit executable! Please reselect...", "SAP Exception",
-				MB_OK);
-			TerminateProcess(GetCurrentProcess(), 0);
-		}
-
-		RegCreateKeyW(HKEY_CURRENT_USER, L"SOFTWARE\\Fireboyd78\\d3hook", &hKey);
-		RegSetValueExW(hKey, L"gameBin", NULL, REG_EXPAND_SZ, reinterpret_cast<LPBYTE>(const_cast<wchar_t*>(str.c_str())),
-			static_cast<DWORD>(str.length() + 1) * sizeof(TCHAR));
-		RegCloseKey(hKey);
-
-		return str;
-	}
-
-	return std::wstring(inst_dir);
+	return fakeCmdl.c_str();
 }
 
 LONG WINAPI CustomUnhandledExceptionFilter(LPEXCEPTION_POINTERS ExceptionInfo)
@@ -231,8 +124,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 {
 	LogFile::WriteLine("Initializing D3Hook...");
 
-	auto gamePath = GetGamePath();
-	g_gameRoot = gamePath;
+	auto gamePath = makeGamePath(L"");
 
 	auto* hkernel = GetModuleHandleW(L"kernel32.dll");
 	auto _AddDllDirectory = (decltype(&AddDllDirectory))GetProcAddress(hkernel, "AddDllDirectory");
@@ -243,7 +135,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 		_SetDefaultDllDirectories(LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS);
 		_AddDllDirectory(gamePath.c_str());	
-		_AddDllDirectory(make_abs_path(L"").c_str());
+		_AddDllDirectory(makeToolPath(L"").c_str());
 	}
 
 	SetCurrentDirectoryW(gamePath.c_str());
@@ -252,7 +144,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	LogFile::Format("Game directory is '%S'\n", gamePath.c_str());
 
 	FILE* game_file = nullptr;
-	_wfopen_s(&game_file, (gamePath + L"Driv3r.exe").c_str(), L"rb");
+	_wfopen_s(&game_file, makeGamePath(L"Driv3r.exe").c_str(), L"rb");
 
 	if (!game_file)
 		return -1;

--- a/src/patches.cpp
+++ b/src/patches.cpp
@@ -1600,13 +1600,13 @@ public:
         //--    }
         //--);
         //--
-        //--InstallCallback("renderer::SetSecondPassSamplerState",
-        //--    &SetSecondPassSamplerState, {
-        //--        cbHook<CALL>(0x5DF32D)
-        //--    }
-        //--);
+//--InstallCallback("renderer::SetSecondPassSamplerState",
+//--    &SetSecondPassSamplerState, {
+//--        cbHook<CALL>(0x5DF32D)
+//--    }
+//--);
 
-        return true;
+return true;
     }
 };
 
@@ -1645,7 +1645,7 @@ public:
 
 template<typename TRet, typename ...Args>
 inline TRet HACK_callthis(LPVOID lpFunc, Args ...args) {
-	return (*(TRet(__thiscall*)(Args...))lpFunc)(args...);
+    return (*(TRet(__thiscall*)(Args...))lpFunc)(args...);
 }
 
 
@@ -1655,52 +1655,50 @@ public:
 
     char* SearchFile(const char* vPath, char* buffer)
     {
-        auto *config = *(CSystemConfigBase**)0x8B8370;
+        auto* config = *(CSystemConfigBase**)0x8B8370;
 
         // our custom path redirection
         if (!_strnicmp(vPath, "D3Hook:", 7))
         {
             static std::string toolBase;
             if (toolBase.empty()) {
-				using convert_type = std::codecvt_utf8<wchar_t>;
-				std::wstring_convert<convert_type, wchar_t> converter;
+                using convert_type = std::codecvt_utf8<wchar_t>;
+                std::wstring_convert<convert_type, wchar_t> converter;
                 toolBase = converter.to_bytes(makeToolPath(L""));
             }
 
             std::sprintf(buffer, "%s%s", toolBase.c_str(), &vPath[7]);
-            return buffer;
         }
-
-        if (!_strnicmp(vPath, "TERR:", 5))
-        {
-            std::sprintf(buffer, "%sTERRITORY\\%s\\%s", gamePath, 
+        else if (!_strnicmp(vPath, "TERR:", 5)) {
+            std::sprintf(buffer, "%sTERRITORY\\%s\\%s", gamePath,
                 config->GetTerritoryString(), &vPath[5]);
-			return _strupr(buffer);
-		}
-
-        if (!_strnicmp(vPath, "LANG:", 5))
-        {
-			std::sprintf(buffer, "%sTERRITORY\\%s\\LOCALE\\%s\\%s", gamePath, 
+        }
+        else if (!_strnicmp(vPath, "LANG:", 5)) {
+            std::sprintf(buffer, "%sTERRITORY\\%s\\LOCALE\\%s\\%s", gamePath,
                 config->GetTerritoryString(),
                 config->GetTextLanguageString(), &vPath[5]);
-			return _strupr(buffer);
         }
-
-		if (!_strnicmp(vPath, "AUDIO:", 6))
-		{
-			std::sprintf(buffer, "%sTERRITORY\\%s\\LOCALE\\%s\\%s", gamePath,
-				config->GetTerritoryString(),
-				config->GetTextLanguageString(), &vPath[6]);
-			return _strupr(buffer);
-		}
-
-        if (!_strnicmp(vPath, "LIVE:", 5)) {
+        else if (!_strnicmp(vPath, "AUDIO:", 6)) {
+            std::sprintf(buffer, "%sTERRITORY\\%s\\LOCALE\\%s\\%s", gamePath,
+                config->GetTerritoryString(),
+                config->GetAudioLanguageString(), &vPath[6]);
+            return _strupr(buffer);
+        }
+        else if (!_strnicmp(vPath, "LIVE:", 5)) {
+            __debugbreak(); /*are there even any of these*/
             std::strncpy(buffer, vPath, 260);
             //return _strupr(buffer); possible bug
             return buffer;
         }
+        else
+            sprintf(buffer, "%s%s", gamePath, vPath);
 
-		sprintf(buffer, "%s%s", gamePath, vPath);
+        if (GetFileAttributesA(buffer) == INVALID_FILE_ATTRIBUTES) {
+            char pathBuf[512]{};
+            sprintf(pathBuf, "Game requested non existent file at %s", buffer);
+            MessageBoxA(nullptr, pathBuf, "D3Hook", MB_ICONWARNING | MB_OK);
+        }
+
 		return _strupr(buffer);
     }
 

--- a/src/util.h
+++ b/src/util.h
@@ -230,12 +230,11 @@ bool GetHookProcAddress(HMODULE hModule, LPCSTR lpProcName, FARPROC *out);
 
 bool GetPathSpec(char *path, char *dest, int destLen);
 
+std::wstring makeGamePath(const std::wstring& rel);
+std::wstring makeToolPath(const std::wstring& rel);
+
 inline bool file_exists(LPCSTR filename) {
-    if (auto file = fopen(filename, "r")) {
-        fclose(file);
-        return true;
-    }
-    return false;
+    return GetFileAttributesA(filename) != INVALID_FILE_ATTRIBUTES;
 }
 
 namespace variadic


### PR DESCRIPTION
Implements a File system hook so we can easily access files in our tool-dir and also overwrite any file requested by the games virtual file system with custom ones from an open iv like mod folder. Also this fixes some game path bugs, and also adds the ability to re-select game path if you start the game while holding the shift key down.